### PR TITLE
➖ Support Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     tags:
-      - '*'
+      - "*"
   pull_request:
   workflow_dispatch:
 
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['3.10', '3.11', '3.12']
-        django: ['3.2', '4.2']
+        python: ["3.9", "3.10", "3.11", "3.12"]
+        django: ["3.2", "4.2"]
 
     name: Run the test suite (Python ${{ matrix.python }}, Django ${{ matrix.django }})
 
@@ -49,7 +49,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
 
       - name: Build sdist and wheel
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
     "django>=3.2"
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{310,311,312}-django{32,42}
+    py{39,310,311,312}-django{32,42}
     isort
     black
     flake8
@@ -9,6 +9,7 @@ skip_missing_interpreters = true
 
 [gh-actions]
 python =
+    3.9: py9
     3.10: py310
     3.11: py311
     3.12: py312


### PR DESCRIPTION
But don't advertise it as such in the README.
No code changes were needed. Feel free to bump drop 3.9 again in future updates; 3.10 does give some nice syntax.

It's just that some CIs are still on 3.9 😬, I just want to provide those poor souls with a version they can use.