### PR TITLE
[#13] Add command option to check that docs are up-to-date

### DIFF
--- a/django_setup_configuration/exceptions.py
+++ b/django_setup_configuration/exceptions.py
@@ -30,6 +30,6 @@ class ImproperlyConfigured(ConfigurationException):
 
 class DocumentationCheckFailed(ConfigurationException):
     """
-    Raised when the documentation based on the configuration models
-    is not up to date
+    Raised when the documentation for the configuration steps
+    is not up-to-date
     """

--- a/docs/config_docs.rst
+++ b/docs/config_docs.rst
@@ -105,3 +105,10 @@ With everything set up, you can generate the docs with the following command:
 ::
 
     python manage.py generate_config_docs
+
+The command can be run with a ``--dry-run`` option to only check if the docs are up-to-date and
+raise an error if they are not (this could be part of your CI):
+
+::
+
+    python manage.py generate_config_docs --dry-run


### PR DESCRIPTION
The PR adds a management command option to run `manage.py generate_config_docs --dry-run` (similar to `manage.py makemigrations --dry-run`). This can be used to check in CI that the docs are in sync with the configuration steps.

Closes #13 

Related: https://taiga.maykinmedia.nl/project/open-inwoner/task/2424