### PR TITLE
Add a validate-only flag to support web-init usage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,6 +225,18 @@ Command Line
 
     python manage.py setup_configuration --yaml-file /path/to/config.yaml
 
+You can also validate that the configuration source can be successfully loaded,
+without actually running the steps, by adding the ``validate-only`` flag:
+
+.. code-block:: bash
+
+    python manage.py setup_configuration --yaml-file /path/to/config.yaml --validate-only
+
+The command will either return 0 and a success message if the configuration file can
+be loaded without issues, otherwise it will return a non-zero exit code and print any
+validation errors. This can be useful e.g. in CI to confirm that your sources are
+valid without actually running any steps.
+
 Programmatically
 ^^^^^^^^^^^^^^^^
 

--- a/django_setup_configuration/management/commands/setup_configuration.py
+++ b/django_setup_configuration/management/commands/setup_configuration.py
@@ -32,9 +32,17 @@ class Command(BaseCommand):
             required=True,
             help="Path to YAML file containing the configurations",
         )
+        parser.add_argument(
+            "--validate-only",
+            action="store_true",
+            default=False,
+            help="Validate that all the step configurations can be successfully loaded "
+            "from source, without actually executing the steps.",
+        )
 
     @transaction.atomic
     def handle(self, **options):
+        validate_only = options["validate_only"]
         yaml_file = Path(options["yaml_file"]).resolve()
         if not yaml_file.exists():
             raise CommandError(f"Yaml file `{yaml_file}` does not exist.")
@@ -73,6 +81,14 @@ class Command(BaseCommand):
             raise CommandError(
                 f"Prerequisites for configuration are not fulfilled: {errors.as_text()}"
             )
+
+        if validate_only:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "All configuration values could be successfully read from source."
+                )
+            )
+            return
 
         self.stdout.write("Executing steps...")
 


### PR DESCRIPTION
Apart from making it easier to validate real-world scenarios, an obvious use-case is to include a CI step which validates the example YAML without actually running it, so it doesn't go stale (this could also be implemented as a simple test by simply invoking `call_command("setup_configuration", validate_only=True, yaml_file="/path/to/example/yaml")`.