### PR TITLE
:bug: [#62] Fix setup-config-usage ToS step links

### DIFF
--- a/django_setup_configuration/documentation/templates/config_doc.rst
+++ b/django_setup_configuration/documentation/templates/config_doc.rst
@@ -1,4 +1,4 @@
-You can use the included ``setup_configuration`` management command to configure your 
+You can use the included ``setup_configuration`` management command to configure your
 instance from a yaml file as follows:
 
 .. code-block:: bash
@@ -31,12 +31,12 @@ Further information can be found at the `django-setup-configuration
 
 {% if show_steps %}
 This projects includes the following configuration steps (click on each step for a
-brief descripion and an example YAML you can include in your config file): 
+brief descripion and an example YAML you can include in your config file):
 {% else %}
-This projects includes the following configuration steps: 
+This projects includes the following configuration steps:
 {% endif %}
 
 {% for step in steps %}
-- {% if show_steps %}`{{ step.title }} <#{{ step.anchor_id }}>`_{% else %} {{ step.title }} {% endif %}
+- {% if show_steps %}`{{ step.title }} <#{{ step.module_path }}>`_{% else %} {{ step.title }} {% endif %}
 {% endfor %}
 {% endif %}

--- a/tests/fixtures/test_documentation.test_usage_directive_outputs_expected_html_with_sphinx.complete.approved.html
+++ b/tests/fixtures/test_documentation.test_usage_directive_outputs_expected_html_with_sphinx.complete.approved.html
@@ -13,7 +13,7 @@
      setup_configuration
     </span>
    </code>
-   management command to configure your 
+   management command to configure your
 instance from a yaml file as follows:
   </p>
   <div class="highlight-bash notranslate">
@@ -72,7 +72,7 @@ brief descripion and an example YAML you can include in your config file):
   <ul class="simple">
    <li>
     <p>
-     <a class="reference external" href="#ref_step_testapp.configuration.UserConfigurationStep">
+     <a class="reference external" href="#testapp.configuration.UserConfigurationStep">
       User Configuration
      </a>
     </p>

--- a/tests/fixtures/test_documentation.test_usage_directive_outputs_expected_html_with_sphinx.steps_autodoc_disabled.approved.html
+++ b/tests/fixtures/test_documentation.test_usage_directive_outputs_expected_html_with_sphinx.steps_autodoc_disabled.approved.html
@@ -13,7 +13,7 @@
      setup_configuration
     </span>
    </code>
-   management command to configure your 
+   management command to configure your
 instance from a yaml file as follows:
   </p>
   <div class="highlight-bash notranslate">
@@ -72,7 +72,7 @@ brief descripion and an example YAML you can include in your config file):
   <ul class="simple">
    <li>
     <p>
-     <a class="reference external" href="#ref_step_testapp.configuration.UserConfigurationStep">
+     <a class="reference external" href="#testapp.configuration.UserConfigurationStep">
       User Configuration
      </a>
     </p>

--- a/tests/fixtures/test_documentation.test_usage_directive_outputs_expected_html_with_sphinx.steps_disabled_toc_enabled.approved.html
+++ b/tests/fixtures/test_documentation.test_usage_directive_outputs_expected_html_with_sphinx.steps_disabled_toc_enabled.approved.html
@@ -13,7 +13,7 @@
      setup_configuration
     </span>
    </code>
-   management command to configure your 
+   management command to configure your
 instance from a yaml file as follows:
   </p>
   <div class="highlight-bash notranslate">

--- a/tests/fixtures/test_documentation.test_usage_directive_outputs_expected_html_with_sphinx.steps_fully_disabled.approved.html
+++ b/tests/fixtures/test_documentation.test_usage_directive_outputs_expected_html_with_sphinx.steps_fully_disabled.approved.html
@@ -13,7 +13,7 @@
      setup_configuration
     </span>
    </code>
-   management command to configure your 
+   management command to configure your
 instance from a yaml file as follows:
   </p>
   <div class="highlight-bash notranslate">

--- a/tests/fixtures/test_documentation.test_usage_directive_outputs_expected_html_with_sphinx.steps_toc_disabled.approved.html
+++ b/tests/fixtures/test_documentation.test_usage_directive_outputs_expected_html_with_sphinx.steps_toc_disabled.approved.html
@@ -13,7 +13,7 @@
      setup_configuration
     </span>
    </code>
-   management command to configure your 
+   management command to configure your
 instance from a yaml file as follows:
   </p>
   <div class="highlight-bash notranslate">


### PR DESCRIPTION
Example of ToS links not working: https://open-zaak--1894.org.readthedocs.build/en/1894/installation/config/openzaak_config_cli.html#ref_step_vng_api_common.contrib.setup_configuration.steps.ApplicatieConfigurationStep